### PR TITLE
Handle inheriting variables from the parent scope

### DIFF
--- a/src/Phug/Formatter/Partial/HandleVariable.php
+++ b/src/Phug/Formatter/Partial/HandleVariable.php
@@ -31,7 +31,10 @@ trait HandleVariable
                 $afterOpen = true;
                 continue;
             }
-            if ($afterOpen && is_array($tokens[$i]) && in_array($tokens[$i][0], [T_FUNCTION, T_USE])) {
+            if ($afterOpen && is_array($tokens[$i]) && in_array($tokens[$i][0], [
+                T_FUNCTION,
+                T_USE,
+            ])) {
                 return true;
             }
         }

--- a/src/Phug/Formatter/Partial/HandleVariable.php
+++ b/src/Phug/Formatter/Partial/HandleVariable.php
@@ -31,7 +31,7 @@ trait HandleVariable
                 $afterOpen = true;
                 continue;
             }
-            if ($afterOpen && is_array($tokens[$i]) && $tokens[$i][0] === T_FUNCTION) {
+            if ($afterOpen && is_array($tokens[$i]) && in_array($tokens[$i][0], [T_FUNCTION, T_USE])) {
                 return true;
             }
         }

--- a/tests/Phug/FormatterTest.php
+++ b/tests/Phug/FormatterTest.php
@@ -262,7 +262,8 @@ class FormatterTest extends TestCase
 
         self::assertSame('A', $return);
 
-        $exp = new ExpressionElement('(($b = "B") && $a = function () use ($b) { return $b; }) ? call_user_func($a) : null');
+        $code = '(($b = "B") && $a = function () use ($b) { return $b; }) ? call_user_func($a) : null';
+        $exp = new ExpressionElement($code);
         $return = eval(str_replace(['<?=', '?>'], ['return', ';'], $formatter->format($exp)));
 
         self::assertSame('B', $return);

--- a/tests/Phug/FormatterTest.php
+++ b/tests/Phug/FormatterTest.php
@@ -262,6 +262,11 @@ class FormatterTest extends TestCase
 
         self::assertSame('A', $return);
 
+        $exp = new ExpressionElement('(($b = "B") && $a = function () use ($b) { return $b; }) ? call_user_func($a) : null');
+        $return = eval(str_replace(['<?=', '?>'], ['return', ';'], $formatter->format($exp)));
+
+        self::assertSame('B', $return);
+
         $exp = new ExpressionElement('($a = function ($a, $b) { return $c; }) ? call_user_func($a, "A", "B") : null');
         $return = eval(str_replace(['<?=', '?>'], ['return', ';'], $formatter->format($exp)));
 


### PR DESCRIPTION
Fixes this:
```pug
- $lineOrders = [];
- $rowSelector = '';

style!= implode("\n", array_map(
    function($sortName, $order) use ($rowSelector) {
      return ".sort-{$sortName} $rowSelector { -ms-flex-order: $order; order: $order }";
    },
    array_keys($lineOrders),
    $lineOrders
  ))
```
throw error: syntax error, unexpected '(', expecting '&' or variable (T_VARIABLE)